### PR TITLE
Fix electrum alloying duplication

### DIFF
--- a/src/generated/resources/data/createmetallurgy/recipe/alloying/electrum.json
+++ b/src/generated/resources/data/createmetallurgy/recipe/alloying/electrum.json
@@ -16,7 +16,7 @@
   "processing_time": 40,
   "results": [
     {
-      "amount": 30,
+      "amount": 20,
       "id": "createmetallurgy:molten_electrum"
     }
   ]


### PR DESCRIPTION
The Electrum alloying recipe permits duplication since it outputs 30 MB while only taking 10 MB of Gold and Silver each.