### PR TITLE
Fix HeatJS custom heat source overlapping Blaze Burner in JEI categories

### DIFF
--- a/src/main/java/fr/lucreeper74/createmetallurgy/compat/jei/category/AlloyingCategory.java
+++ b/src/main/java/fr/lucreeper74/createmetallurgy/compat/jei/category/AlloyingCategory.java
@@ -20,7 +20,7 @@ public class AlloyingCategory extends FoundryBasinCategory {
         super.draw(recipe, iRecipeSlotsView, graphics, mouseX, mouseY);
 
         HeatCondition requiredHeat = recipe.getRequiredHeat();
-        if (requiredHeat != HeatCondition.NONE)
+        if (requiredHeat != HeatCondition.NONE && !customHeatSource)
             heater.withHeat(requiredHeat.visualizeAsBlazeBurner())
                     .draw(graphics, getBackground().getWidth() / 2 + 3, 55);
         mixer.draw(graphics, getBackground().getWidth() / 2 + 3, 34);

--- a/src/main/java/fr/lucreeper74/createmetallurgy/compat/jei/category/FoundryBasinCategory.java
+++ b/src/main/java/fr/lucreeper74/createmetallurgy/compat/jei/category/FoundryBasinCategory.java
@@ -32,6 +32,7 @@ import static fr.lucreeper74.createmetallurgy.CreateMetallurgy.HEATJS_LOADED;
 public class FoundryBasinCategory extends CreateRecipeCategory<FoundryBasinRecipe> {
 
     private final boolean needsHeating;
+    protected boolean customHeatSource = false;
 
     public FoundryBasinCategory(Info<FoundryBasinRecipe> info, boolean needsHeating) {
         super(info);
@@ -122,9 +123,9 @@ public class FoundryBasinCategory extends CreateRecipeCategory<FoundryBasinRecip
         AllGuiTextures shadow = noHeat ? AllGuiTextures.JEI_SHADOW : AllGuiTextures.JEI_LIGHT;
         shadow.render(graphics, 81, 58 + (noHeat ? 10 : 30));
 
+        customHeatSource = false;
         if (HEATJS_LOADED) {
-            // TODO: need to prevent blaze burner from drawing if this is active to avoid overlapping
-            CategoryHelper.drawCustomHeatSource(graphics, recipeSlotsView, recipe,
+            customHeatSource = CategoryHelper.drawCustomHeatSource(graphics, recipeSlotsView, recipe,
                     background.getWidth() / 2 + 3, 55, background.getWidth(), background.getHeight(), mouseX, mouseY);
         }
 

--- a/src/main/java/fr/lucreeper74/createmetallurgy/compat/jei/category/FoundryBasinCategory.java
+++ b/src/main/java/fr/lucreeper74/createmetallurgy/compat/jei/category/FoundryBasinCategory.java
@@ -32,7 +32,7 @@ import static fr.lucreeper74.createmetallurgy.CreateMetallurgy.HEATJS_LOADED;
 public class FoundryBasinCategory extends CreateRecipeCategory<FoundryBasinRecipe> {
 
     private final boolean needsHeating;
-    protected boolean customHeatSource = false;
+    protected boolean customHeatSource;
 
     public FoundryBasinCategory(Info<FoundryBasinRecipe> info, boolean needsHeating) {
         super(info);

--- a/src/main/java/fr/lucreeper74/createmetallurgy/compat/jei/category/MeltingCategory.java
+++ b/src/main/java/fr/lucreeper74/createmetallurgy/compat/jei/category/MeltingCategory.java
@@ -26,7 +26,7 @@ public class MeltingCategory extends FoundryBasinCategory {
         drawProcessTime(recipe, graphics, 55);
 
         HeatCondition requiredHeat = recipe.getRequiredHeat();
-        if (requiredHeat != HeatCondition.NONE)
+        if (requiredHeat != HeatCondition.NONE && !customHeatSource)
             heater.withHeat(requiredHeat.visualizeAsBlazeBurner())
                     .draw(graphics, getBackground().getWidth() / 2 + 3, 55);
         castingtop.draw(graphics, getBackground().getWidth() / 2 + 3, 34);


### PR DESCRIPTION
When a recipe had a custom HeatJS heat source, the Blaze Burner was still being drawn on top of it in the Melting and Alloying JEI categories.

CategoryHelper.drawCustomHeatSource already returns a boolean for exactly this case, but the return value was never used. Added a customHeatSource flag to FoundryBasinCategory to track it, skip the Blaze Burner draw in the subclasses when a custom source is already rendered.